### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/freebora/__main__.py
+++ b/freebora/__main__.py
@@ -51,7 +51,7 @@ def main():
     args = p.parse_args()
 
     if args.version:
-        print('Freebora version %s' % __version__)
+        print('Freebora version {0!s}'.format(__version__))
         sys.exit()
 
     # Create destination folder if needed.
@@ -61,7 +61,7 @@ def main():
             os.makedirs(args.dest, exist_ok=True)
             created = True
         if args.verbose and os.path.exists(args.dest) and created:
-            print('Created destination folder: "%s"' % args.dest)
+            print('Created destination folder: "{0!s}"'.format(args.dest))
 
     # Get list of free ebook categories.
     if args.list_cats_sync:
@@ -74,7 +74,7 @@ def main():
         if not os.path.exists(path) or args.overwrite:
             for url in  download_filelist_sync(cat=args.cat, verbose=args.verbose):
                 with open(path, 'a') as f:
-                    f.write('%s\n' % url)
+                    f.write('{0!s}\n'.format(url))
 
     # Fetch PDFs for given URLs.
     if args.fetch_sync or args.fetch_async:
@@ -83,7 +83,7 @@ def main():
         elif args.fetch_async:
             path = args.fetch_async
         urls = open(os.path.join(args.dest, path)).read().strip().split('\n')
-        print('#URLs found: %d' % len(urls))
+        print('#URLs found: {0:d}'.format(len(urls)))
 
         if args.fetch_sync:
             f = download_files_sync

--- a/runtests.py
+++ b/runtests.py
@@ -3096,7 +3096,7 @@ class DictImporter(object):
 
         co = compile(s, fullname, 'exec')
         module = sys.modules.setdefault(fullname, ModuleType(fullname))
-        module.__file__ = "%s/%s" % (__file__, fullname)
+        module.__file__ = "{0!s}/{1!s}".format(__file__, fullname)
         module.__loader__ = self
         if is_pkg:
             module.__path__ = [fullname]

--- a/tests/test_networking.py
+++ b/tests/test_networking.py
@@ -8,7 +8,7 @@ def test_networking():
 
     dest = os.path.join(os.path.dirname(__file__), 'ebooks')
     cat = 'networking'
-    urls_path = '%s/%s-urls.txt' % (dest, cat)
+    urls_path = '{0!s}/{1!s}-urls.txt'.format(dest, cat)
     verbose = True
 
     # Create destination folder if needed.
@@ -17,7 +17,7 @@ def test_networking():
     # Get list of URLs for free ebooks.
     for url in freebora.download_filelist_sync(cat=cat, verbose=verbose):
         with open(urls_path, 'a') as f:
-            f.write('%s\n' % url)
+            f.write('{0!s}\n'.format(url))
 
     # Fetch PDFs for given URLs.
     urls = open(urls_path).read().strip().split('\n')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:deeplook:freebora?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:deeplook:freebora?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)